### PR TITLE
Code segments

### DIFF
--- a/training-1/Cargo.toml
+++ b/training-1/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 
 [dependencies]
-rs6502 = { path = "../../rs6502" }
+rs6502 = "0.2.0"
 vm = { path = "../vm" }
 
 [dependencies.sdl2]

--- a/training-1/Cargo.toml
+++ b/training-1/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 
 [dependencies]
-rs6502 = "0.1.0"
+rs6502 = { path = "../../rs6502" }
 vm = { path = "../vm" }
 
 [dependencies.sdl2]

--- a/training-1/level.asm
+++ b/training-1/level.asm
@@ -1,5 +1,6 @@
 
 ; This code runs Training Level 1 of the game, hakka.
+.ORG $5000
 
 ; 16-bit Ship X position
 X_0 = $00

--- a/training-1/level.asm
+++ b/training-1/level.asm
@@ -45,6 +45,8 @@ CLI
 DownArrowEnd:
 RTS
 
+.ORG $6000
+
 UpArrow:
 
 LDA KEY

--- a/training-1/level.asm
+++ b/training-1/level.asm
@@ -1,6 +1,5 @@
 
 ; This code runs Training Level 1 of the game, hakka.
-.ORG $5000
 
 ; 16-bit Ship X position
 X_0 = $00
@@ -44,8 +43,6 @@ CLI
 
 DownArrowEnd:
 RTS
-
-.ORG $6000
 
 UpArrow:
 

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -23,9 +23,10 @@ const WINDOW_HEIGHT: u32 = 720;
 
 fn main() {
 
+    let cpu = init_cpu();
     let segments = assemble("level.asm");
-    let cpu = init_cpu(&segments);
-    let mut vm = VirtualMachine::new(cpu, 0xC000, 150);
+    let mut vm = VirtualMachine::new(cpu, 150);
+    vm.load_code_segments(segments);
 
     let sdl_context = sdl2::init().unwrap();
     let ttf_context = sdl2::ttf::init().unwrap();
@@ -143,11 +144,8 @@ fn assemble<P>(path: P) -> Vec<CodeSegment>
     assembler.assemble_file(path, 0xC000).unwrap()
 }
 
-fn init_cpu(segments: &[CodeSegment]) -> Cpu {
+fn init_cpu() -> Cpu {
     let mut cpu = Cpu::new();
-    for segment in segments {
-        cpu.load(&segment.code[..], segment.address).unwrap();
-    }
     cpu.flags.interrupt_disabled = false;
 
     cpu.memory[0x00] = 0x90;

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 
 [dependencies]
-rs6502 = "0.1.0"
+rs6502 = { path = "../../rs6502" }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 
 [dependencies]
-rs6502 = { path = "../../rs6502", version = "0.2.0" }
+rs6502 = "0.2.0"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 
 [dependencies]
-rs6502 = { path = "../../rs6502" }
+rs6502 = { path = "../../rs6502", version = "0.2.0" }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -4,7 +4,7 @@ use std::io::{self, BufRead, Write};
 use std::sync::mpsc::{channel, Receiver};
 use std::thread;
 
-use rs6502::{Cpu, Disassembler};
+use rs6502::{CodeSegment, Cpu, Disassembler};
 
 const HELPTEXT: &'static str = "
 
@@ -62,7 +62,7 @@ pub struct MemoryMonitor {
 pub struct VirtualMachine {
     pub cpu: Cpu,
     pub monitor: MemoryMonitor,
-    code_offset: u16,
+    segments: Vec<CodeSegment>,
     clock_rate: Option<u32>,
     receiver: Receiver<String>,
     last_command: String,
@@ -72,7 +72,7 @@ pub struct VirtualMachine {
 }
 
 impl VirtualMachine {
-    pub fn new<CR>(cpu: Cpu, code_offset: u16, clock_rate: CR) -> VirtualMachine
+    pub fn new<CR>(cpu: Cpu, clock_rate: CR) -> VirtualMachine
         where CR: Into<Option<u32>>
     {
         let (tx, rx) = channel();
@@ -98,7 +98,7 @@ impl VirtualMachine {
 
         VirtualMachine {
             cpu: cpu,
-            code_offset: code_offset,
+            segments: Vec::new(),
             clock_rate: clock_rate.into(),
             receiver: rx,
             monitor: MemoryMonitor {
@@ -111,6 +111,18 @@ impl VirtualMachine {
             broken: false,
             step: false,
         }
+    }
+
+    pub fn load_code_segments(&mut self, segments: Vec<CodeSegment>) {
+        if segments.len() == 0 {
+            return;
+        }
+        self.segments = segments;
+        for segment in &self.segments {
+            self.cpu.load(&segment.code, segment.address);
+        }
+
+        self.cpu.registers.PC = self.segments[0].address;
     }
 
     /// Cycles the Virtual Machine CPU according to the clock rate
@@ -297,21 +309,30 @@ impl VirtualMachine {
         println!("");
         println!("-- Disassembly --");
 
-        let disassembler = Disassembler::with_offset(self.code_offset);
-        let pairs = disassembler.disassemble_with_addresses(self.cpu.get_code());
-        let result = self.highlight_lines(self.cpu.registers.PC as usize, pairs, false).join("");
-        print!("{}", result);
+        for segment in &self.segments {
+            println!(".ORG ${:04X}", segment.address);
+            let disassembler = Disassembler::with_offset(segment.address);
+            let pairs = disassembler.disassemble_with_addresses(&segment.code);
+            let result = self.highlight_lines(self.cpu.registers.PC as usize,
+                                 pairs,
+                                 segment.address,
+                                 false)
+                .join("");
+            print!("{}", result);
+            println!("");
+        }
     }
 
     fn dump_local_disassembly(&self) {
         println!("");
         println!("-- Disassembly --");
 
-        let disassembler = Disassembler::with_offset(self.code_offset);
         let pc = self.cpu.registers.PC as usize;
-        let code = self.cpu.get_code();
-        let pairs = disassembler.disassemble_with_addresses(code);
-        let result = self.highlight_lines(pc, pairs, true).join("");
+        let local_segment = self.get_local_segment(pc);
+        println!("Found local segment at: {:04X}", local_segment.address);
+        let disassembler = Disassembler::with_offset(local_segment.address);
+        let pairs = disassembler.disassemble_with_addresses(&local_segment.code);
+        let result = self.highlight_lines(pc, pairs, local_segment.address, true).join("");
         print!("{}", result);
     }
 
@@ -364,24 +385,36 @@ impl VirtualMachine {
                  self.cpu.stack.pointer);
     }
 
+    fn get_local_segment(&self, pc: usize) -> &CodeSegment {
+        for segment in &self.segments {
+            let addr = segment.address as usize;
+            if pc >= addr && pc <= addr + segment.code.len() {
+                return segment;
+            }
+        }
+
+        &self.segments[0]
+    }
+
     fn highlight_lines(&self,
                        pc: usize,
                        pairs: Vec<(String, u16)>,
+                       segment_start: u16,
                        limit_results: bool)
                        -> Vec<String> {
         let mut result = Vec::new();
 
-        let base = pc - self.code_offset as usize;
+        let base = pc as isize - segment_start as isize;
 
         for pair in pairs {
             if limit_results {
                 let start = if base > 0x0A { base - 0x0A } else { 0 };
-                if (pair.1 as usize) < start || (pair.1 as usize) > base + 0x0A {
+                if (pair.1 as isize) < start || (pair.1 as isize) > base + 0x0A {
                     continue;
                 }
             }
-            let current_line = pc as u16 == self.code_offset + pair.1;
-            let breakpoint = self.breakpoints[self.code_offset as usize + pair.1 as usize] > 0x00;
+            let current_line = pc as u16 == segment_start + pair.1;
+            let breakpoint = self.breakpoints[segment_start as usize + pair.1 as usize] > 0x00;
 
             if breakpoint && current_line {
                 result.push(format!("> * {}", pair.0));

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -329,7 +329,6 @@ impl VirtualMachine {
 
         let pc = self.cpu.registers.PC as usize;
         let local_segment = self.get_local_segment(pc);
-        println!("Found local segment at: {:04X}", local_segment.address);
         let disassembler = Disassembler::with_offset(local_segment.address);
         let pairs = disassembler.disassemble_with_addresses(&local_segment.code);
         let result = self.highlight_lines(pc, pairs, local_segment.address, true).join("");


### PR DESCRIPTION
This PR introduces the concept of code segments.

The `rs6502` package now supports the `.ORG` directive, to layout code in memory and this PR makes adjustments to account for the changes in the API there.

This doesn't currently update the available training level in any way. However, it paves the way for more complicated/interesting levels in the future with code spread out across different memory pages. It also makes way to adding interrupt handlers wherever we want.

This PR also includes debugger updates to account for the `.ORG` directive. An example screenshot of the `source` listing is below:

![screen shot 2016-12-21 at 3 13 29 pm](https://cloud.githubusercontent.com/assets/2499070/21377285/8c7e4ae6-c791-11e6-98c4-0b9aadf58294.png)

Note the disassembly now includes `.ORG` directives in the output to help show where code is in memory.