### PR TITLE
Add ways to enter stepping mode without setting a breakpoint first

### DIFF
--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -267,7 +267,8 @@ impl VirtualMachine {
                         println!("ERR: Unable to parse breakpoint address");
                     }
                 } else {
-                    println!("ERR: Requires 1 argument");
+                    self.broken = true;
+                    println!("Execution stopped");
                 }
             }
 
@@ -277,6 +278,7 @@ impl VirtualMachine {
             }
 
             if parts[0] == "step" || parts[0] == "s" {
+                self.broken = true;
                 self.step = true;
             }
 


### PR DESCRIPTION
I just played the game without looking at the tutorial first, and I really love the idea so far.
I noticed some usability issues you most likely already know about, like history scrolling etc.
One small thing I noticed though was that in my first attempt I tried to enter stepping mode without setting a breakpoint first. As this is a simple fix, I just implemented it myself for this PR.
What do you think about it?