### PR TITLE
Minor improvements to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A game that you can't pass simply by playing the game. You have to hack it.
 is being released to test the waters to see if people find it interesting.
 
 ## Requirements
-Requires `SDL2`, `SDL2_image` and `SDL2_ttf`.
+Requires `SDL2`, `SDL2_image`, `SDL2_ttf` and `SDL2_gfx`.
 
 [You can see instructions for installing the SDL2 development libraries here](https://github.com/AngryLawyer/rust-sdl2#sdl20-development-libraries)
 

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -84,7 +84,8 @@ fn main() {
             } else {
                 match event {
                     Event::Quit { .. } => break 'running,
-                    Event::KeyUp { keycode: Option::Some(Keycode::Backquote), .. } => {
+                    Event::KeyUp { keycode: Option::Some(Keycode::Backquote), .. } |
+                    Event::KeyUp { keycode: Option::Some(Keycode::T), .. }     => {
                         vm.console.toggle();
                     }
                     Event::KeyDown { keycode: Option::Some(Keycode::Up), .. } => {

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -87,7 +87,10 @@ fn main() {
                     Event::KeyUp { keycode, .. } => {
                         vm.cpu.memory[0x04] = 0;
                         match keycode {
-                            Some(Keycode::Backquote) | Some(Keycode::Backslash) => vm.console.toggle(),
+                            Some(Keycode::Backquote) |
+                            Some(Keycode::Backslash) => {
+                                vm.console.toggle();
+                            },
                             _ => (),
                         }
                     }

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -84,7 +84,8 @@ fn main() {
             } else {
                 match event {
                     Event::Quit { .. } => break 'running,
-                    Event::KeyUp { keycode: Option::Some(Keycode::Backquote), .. } => {
+                    Event::KeyUp { keycode: Option::Some(Keycode::Backquote), .. } | 
+                    Event::KeyUp { keycode: Option::Some(Keycode::Backslash), .. }   => {
                         vm.console.toggle();
                     }
                     Event::KeyDown { keycode: Option::Some(Keycode::Up), .. } => {

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -84,8 +84,7 @@ fn main() {
             } else {
                 match event {
                     Event::Quit { .. } => break 'running,
-                    Event::KeyUp { keycode: Option::Some(Keycode::Backquote), .. } |
-                    Event::KeyUp { keycode: Option::Some(Keycode::T), .. }     => {
+                    Event::KeyUp { keycode: Option::Some(Keycode::Backquote), .. } => {
                         vm.console.toggle();
                     }
                     Event::KeyDown { keycode: Option::Some(Keycode::Up), .. } => {

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -93,7 +93,7 @@ impl<'a> Console<'a> {
     pub fn process(&mut self, event: &Event) {
         match *event {
             Event::KeyUp { keycode: Option::Some(Keycode::Backquote), .. } |
-            Event::KeyUp { keycode: Option::Some(Keycode::Backslash), .. }           => {
+            Event::KeyUp { keycode: Option::Some(Keycode::Backslash), .. }   => {
                 self.toggle();
             }
             Event::TextInput { ref text, .. } => {

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -92,10 +92,6 @@ impl<'a> Console<'a> {
 
     pub fn process(&mut self, event: &Event) {
         match *event {
-            Event::KeyUp { keycode: Option::Some(Keycode::Backquote), .. } |
-            Event::KeyUp { keycode: Option::Some(Keycode::Backslash), .. }   => {
-                self.toggle();
-            }
             Event::TextInput { ref text, .. } => {
                 if self.visible {
                     if text == "`" || text == "\\" {
@@ -164,6 +160,11 @@ impl<'a> Console<'a> {
                         }
                         Some(Keycode::Home) => {
                             self.cursor_position = 0;
+                        },
+                        // Toggle console
+                        Some(Keycode::Backquote) |
+                        Some(Keycode::Backslash) => {
+                            self.toggle();
                         }
                         _ => (),
                     }

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -112,7 +112,8 @@ impl<'a> Console<'a> {
 
     pub fn process(&mut self, event: &Event) {
         match *event {
-            Event::KeyUp { keycode: Option::Some(Keycode::Backquote), .. } => {
+            Event::KeyUp { keycode: Option::Some(Keycode::Backquote), .. } |
+            Event::KeyUp { keycode: Option::Some(Keycode::Backslash), .. }           => {
                 self.toggle();
             }
             Event::TextInput { ref text, .. } => {


### PR DESCRIPTION
A couple of minor improvements to console usability

- Allows using \ for toggling console (Useful on other keyboard layouts)
- Shows the typed message after it is canceled with ^C, in line with the way linux terminals works
- Specified that SDL2_gfx is needed in README