### PR TITLE
Fixed wide char handling

### DIFF
--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -13,7 +13,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use find_folder::Search;
 
 use sdl2::event::Event;
-use sdl2::keyboard::*;
+use sdl2::keyboard::{Keycode, Scancode};
 use sdl2::image::LoadTexture;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
@@ -101,11 +101,9 @@ fn main() {
                             _ => (),
                         }
                     }
-                    Event::KeyDown { keycode, scancode, timestamp, keymod, .. } => {
-                        if !keymod.intersects(LALTMOD | LCTRLMOD | LSHIFTMOD | RALTMOD | RCTRLMOD | RSHIFTMOD) {
-                            if let Some(Scancode::Grave) = scancode {
-                                vm.console.toggle(timestamp);
-                            }
+                    Event::KeyDown { keycode, scancode, timestamp, .. } => {
+                        if let Some(Scancode::Grave) = scancode {
+                            vm.console.toggle(timestamp);
                         }
 
                         match keycode {

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -13,7 +13,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use find_folder::Search;
 
 use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
+use sdl2::keyboard::{Keycode, Scancode};
 use sdl2::image::LoadTexture;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
@@ -92,22 +92,26 @@ fn main() {
                 vm.console.process(&event);
             } else {
                 match event {
-                    Event::TextInput { ref text, .. } => {
-                        if text == "`" || text == "\\" {
-                            vm.console.toggle();
-                        }
-                    }
                     Event::Quit { .. } => break 'running,
                     Event::KeyUp { .. } => {
                         vm.cpu.memory[0x04] = 0;
                     }
-                    Event::KeyDown { keycode, .. } => {
-                        if let Some(Keycode::Escape) = keycode {
-                            break 'running;
-                        } else if let Some(Keycode::Up) = keycode {
-                            vm.cpu.memory[0x04] = 38;
-                        } else if let Some(Keycode::Down) = keycode {
-                            vm.cpu.memory[0x04] = 40;
+                    Event::KeyDown { keycode, scancode, timestamp, .. } => {
+                        if let Some(Scancode::Grave) = scancode {
+                            vm.console.toggle(timestamp);
+                        }
+
+                        match keycode {
+                            Some(Keycode::Escape) => break 'running,
+
+                            //Movement
+                            Some(Keycode::Up) => {
+                                vm.cpu.memory[0x04] = 38;
+                            },
+                            Some(Keycode::Down) => {
+                                vm.cpu.memory[0x04]  = 40;
+                            },
+                            _ => (),
                         }
                     }
                     _ => (),

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -13,7 +13,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use find_folder::Search;
 
 use sdl2::event::Event;
-use sdl2::keyboard::{Keycode, Scancode};
+use sdl2::keyboard::Keycode;
 use sdl2::image::LoadTexture;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
@@ -92,6 +92,11 @@ fn main() {
                 vm.console.process(&event);
             } else {
                 match event {
+                    Event::TextInput { ref text, .. } => {
+                        if text == "`" || text == "\\" {
+                            vm.console.toggle();
+                        }
+                    }
                     Event::Quit { .. } => break 'running,
                     Event::KeyUp { keycode, .. } => {
                         match keycode {
@@ -101,22 +106,13 @@ fn main() {
                             _ => (),
                         }
                     }
-                    Event::KeyDown { keycode, scancode, timestamp, .. } => {
-                        if let Some(Scancode::Grave) = scancode {
-                            vm.console.toggle(timestamp);
-                        }
-
-                        match keycode {
-                            Some(Keycode::Escape) => break 'running,
-
-                            //Movement
-                            Some(Keycode::Up) => {
-                                vm.cpu.memory[0x04] = 38;
-                            },
-                            Some(Keycode::Down) => {
-                                vm.cpu.memory[0x04]  = 40;
-                            },
-                            _ => (),
+                    Event::KeyDown { keycode, .. } => {
+                        if let Some(Keycode::Escape) = keycode {
+                            break 'running;
+                        } else if let Some(Keycode::Up) = keycode {
+                            vm.cpu.memory[0x04] = 38;
+                        } else if let Some(Keycode::Down) = keycode {
+                            vm.cpu.memory[0x04] = 40;
                         }
                     }
                     _ => (),

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -93,8 +93,13 @@ fn main() {
             } else {
                 match event {
                     Event::Quit { .. } => break 'running,
-                    Event::KeyUp { .. } => {
-                        vm.cpu.memory[0x04] = 0;
+                    Event::KeyUp { keycode, .. } => {
+                        match keycode {
+                            Some(Keycode::Up) | Some(Keycode::Down) => {
+                                vm.cpu.memory[0x04] = 0;
+                            }
+                            _ => (),
+                        }
                     }
                     Event::KeyDown { keycode, scancode, timestamp, .. } => {
                         if let Some(Scancode::Grave) = scancode {

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -13,7 +13,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use find_folder::Search;
 
 use sdl2::event::Event;
-use sdl2::keyboard::{Keycode, Scancode};
+use sdl2::keyboard::*;
 use sdl2::image::LoadTexture;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
@@ -101,9 +101,11 @@ fn main() {
                             _ => (),
                         }
                     }
-                    Event::KeyDown { keycode, scancode, timestamp, .. } => {
-                        if let Some(Scancode::Grave) = scancode {
-                            vm.console.toggle(timestamp);
+                    Event::KeyDown { keycode, scancode, timestamp, keymod, .. } => {
+                        if !keymod.intersects(LALTMOD | LCTRLMOD | LSHIFTMOD | RALTMOD | RCTRLMOD | RSHIFTMOD) {
+                            if let Some(Scancode::Grave) = scancode {
+                                vm.console.toggle(timestamp);
+                            }
                         }
 
                         match keycode {

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use sdl2::event::Event;
 use sdl2::gfx::primitives::DrawRenderer;
-use sdl2::keyboard::{Keycode, Scancode};
+use sdl2::keyboard::*;
 use sdl2::pixels::{Color, PixelFormatEnum};
 use sdl2::rect::Rect;
 use sdl2::render::{BlendMode, Renderer, Texture, TextureQuery};
@@ -117,14 +117,16 @@ impl<'a> Console<'a> {
                     }
                 }
             }
-            Event::KeyDown { keycode, scancode, timestamp, .. } => {
+            Event::KeyDown { keycode, scancode, timestamp, keymod, .. } => {
                 if self.visible {
-                    // The 'Grave' scancode coresponds to the key in the top-left corner of the
-                    // keyboard, bellow escape, on (hopefully) all keyboard layouts.
-                    if let Some(Scancode::Grave) = scancode {
-                        self.toggle(timestamp);
-                        return;
-                    } 
+                    if !keymod.intersects(LALTMOD | LCTRLMOD | LSHIFTMOD | RALTMOD | RCTRLMOD | RSHIFTMOD) {
+                        // The 'Grave' scancode coresponds to the key in the top-left corner of the
+                        // keyboard, bellow escape, on (hopefully) all keyboard layouts.
+                        if let Some(Scancode::Grave) = scancode {
+                            self.toggle(timestamp);
+                            return;
+                        } 
+                    }
 
                     match keycode { 
                         Some(Keycode::LCtrl) |

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -277,7 +277,7 @@ impl<'a> Console<'a> {
 
     pub fn add_text(&mut self, input: &str) {
         self.input_buffer.insert(self.cursor_position, input.chars().next().unwrap());
-        self.cursor_position += 1;
+        self.cursor_position += input.len();
     }
 
     pub fn commit(&mut self) {
@@ -291,19 +291,28 @@ impl<'a> Console<'a> {
     pub fn cursor_left(&mut self) {
         if self.cursor_position > 0 {
             self.cursor_position -= 1;
+            while !self.input_buffer.is_char_boundary(self.cursor_position) {
+                self.cursor_position -= 1;
+            }
         }
     }
 
     pub fn cursor_right(&mut self) {
         if self.cursor_position < self.input_buffer.len() {
             self.cursor_position += 1;
+            while !self.input_buffer.is_char_boundary(self.cursor_position) {
+                self.cursor_position += 1;
+            }
         }
     }
 
     pub fn backspace(&mut self) {
         if self.visible && self.cursor_position > 0 {
-            self.input_buffer.remove(self.cursor_position - 1);
             self.cursor_position -= 1;
+            while !self.input_buffer.is_char_boundary(self.cursor_position) {
+                self.cursor_position -= 1;
+            }
+            self.input_buffer.remove(self.cursor_position);
         }
     }
 

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use sdl2::event::Event;
 use sdl2::gfx::primitives::DrawRenderer;
-use sdl2::keyboard::Keycode;
+use sdl2::keyboard::{Keycode, Scancode};
 use sdl2::pixels::{Color, PixelFormatEnum};
 use sdl2::rect::Rect;
 use sdl2::render::{BlendMode, Renderer, Texture, TextureQuery};
@@ -22,6 +22,7 @@ const FONT_SIZE: u16 = 18;
 
 pub struct Console<'a> {
     pub visible: bool,
+    visible_start_time: u32, // Used to ensure that the KeyDown event that opens the console does not trigger text input
 
     font_file: &'a str,
     leader: Text,
@@ -71,6 +72,8 @@ impl<'a> Console<'a> {
 
         Console {
             visible: false,
+            visible_start_time: 0,
+
             font_file: font_file,
             leader: Text::new(ttf_context,
                               &mut renderer,
@@ -98,12 +101,8 @@ impl<'a> Console<'a> {
 
     pub fn process(&mut self, event: &Event) {
         match *event {
-            Event::TextInput { ref text, .. } => {
-                if self.visible {
-                    if text == "`" || text == "\\" {
-                        self.toggle();
-                        return;
-                    }
+            Event::TextInput { ref text, timestamp, .. } => {
+                if self.visible && timestamp != self.visible_start_time {
                     self.add_text(text);
                 }
             }
@@ -118,8 +117,15 @@ impl<'a> Console<'a> {
                     }
                 }
             }
-            Event::KeyDown { keycode, .. } => {
+            Event::KeyDown { keycode, scancode, timestamp, .. } => {
                 if self.visible {
+                    // The 'Grave' scancode coresponds to the key in the top-left corner of the
+                    // keyboard, bellow escape, on (hopefully) all keyboard layouts.
+                    if let Some(Scancode::Grave) = scancode {
+                        self.toggle(timestamp);
+                        return;
+                    } 
+
                     match keycode { 
                         Some(Keycode::LCtrl) |
                         Some(Keycode::RCtrl) => self.ctrl = true,
@@ -260,8 +266,11 @@ impl<'a> Console<'a> {
     }
 
     /// Toggles the visibility of the Console
-    pub fn toggle(&mut self) {
+    pub fn toggle(&mut self, time: u32) {
         self.visible = !self.visible;
+        if self.visible {
+            self.visible_start_time = time;
+        }
     }
 
     pub fn add_text(&mut self, input: &str) {

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use sdl2::event::Event;
 use sdl2::gfx::primitives::DrawRenderer;
-use sdl2::keyboard::*;
+use sdl2::keyboard::{Keycode, Scancode};
 use sdl2::pixels::{Color, PixelFormatEnum};
 use sdl2::rect::Rect;
 use sdl2::render::{BlendMode, Renderer, Texture, TextureQuery};
@@ -117,16 +117,14 @@ impl<'a> Console<'a> {
                     }
                 }
             }
-            Event::KeyDown { keycode, scancode, timestamp, keymod, .. } => {
+            Event::KeyDown { keycode, scancode, timestamp, .. } => {
                 if self.visible {
-                    if !keymod.intersects(LALTMOD | LCTRLMOD | LSHIFTMOD | RALTMOD | RCTRLMOD | RSHIFTMOD) {
-                        // The 'Grave' scancode coresponds to the key in the top-left corner of the
-                        // keyboard, bellow escape, on (hopefully) all keyboard layouts.
-                        if let Some(Scancode::Grave) = scancode {
-                            self.toggle(timestamp);
-                            return;
-                        } 
-                    }
+                    // The 'Grave' scancode coresponds to the key in the top-left corner of the
+                    // keyboard, bellow escape, on (hopefully) all keyboard layouts.
+                    if let Some(Scancode::Grave) = scancode {
+                        self.toggle(timestamp);
+                        return;
+                    } 
 
                     match keycode { 
                         Some(Keycode::LCtrl) |

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -216,7 +216,7 @@ impl<'a> Console<'a> {
     }
 
     fn history_navigate_forward(&mut self) {
-        if self.history_position < self.command_history.len() - 1 {
+        if self.command_history.len() > 0 && self.history_position < self.command_history.len() - 1 {
             self.input_buffer = self.command_history[self.history_position + 1].clone();
             self.cursor_position = self.input_buffer.len();
             if self.history_position < self.command_history.len() {

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -129,11 +129,7 @@ impl<'a> VirtualMachine<'a> {
                     self.console.println("");
                     self.console
                         .println(format!("BREAKPOINT hit at {:04X}", self.cpu.registers.PC));
-                    // We are supposed to pass the current timestamp to prevent the keys which are
-                    // used to toggle the console from inputing text into the console. As no key
-                    // is pressed to open the console in this instance, passing the time is not
-                    // strictly necesarry
-                    self.console.toggle(0);
+                    self.console.toggle();
                 }
                 // If we stepped, dump the local disassembly
                 if self.step {
@@ -151,7 +147,7 @@ impl<'a> VirtualMachine<'a> {
                 self.broken = true;
                 self.console.println("");
                 self.console.println(format!("BREAKPOINT hit at {:04X}", self.cpu.registers.PC));
-                self.console.toggle(0);
+                self.console.toggle();
             }
         }
     }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -129,7 +129,11 @@ impl<'a> VirtualMachine<'a> {
                     self.console.println("");
                     self.console
                         .println(format!("BREAKPOINT hit at {:04X}", self.cpu.registers.PC));
-                    self.console.toggle();
+                    // We are supposed to pass the current timestamp to prevent the keys which are
+                    // used to toggle the console from inputing text into the console. As no key
+                    // is pressed to open the console in this instance, passing the time is not
+                    // strictly necesarry
+                    self.console.toggle(0);
                 }
                 // If we stepped, dump the local disassembly
                 if self.step {
@@ -147,7 +151,7 @@ impl<'a> VirtualMachine<'a> {
                 self.broken = true;
                 self.console.println("");
                 self.console.println(format!("BREAKPOINT hit at {:04X}", self.cpu.registers.PC));
-                self.console.toggle();
+                self.console.toggle(0);
             }
         }
     }


### PR DESCRIPTION
Previously, there would be a misalignment between string length and cursor position if multi-byte characters were entered. These commits fix that, so now characters such as æøå§¦ can be entered.

Some commits are related to scancode stuff, but these are moved to a separate branch, for another pull request.