### PR TITLE
Use scancodes to toggle console, for uniformity across keyboard layouts

### DIFF
--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -13,7 +13,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use find_folder::Search;
 
 use sdl2::event::Event;
-use sdl2::keyboard::Keycode;
+use sdl2::keyboard::*;
 use sdl2::image::LoadTexture;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
@@ -92,22 +92,28 @@ fn main() {
                 vm.console.process(&event);
             } else {
                 match event {
-                    Event::TextInput { ref text, .. } => {
-                        if text == "`" || text == "\\" {
-                            vm.console.toggle();
-                        }
-                    }
                     Event::Quit { .. } => break 'running,
                     Event::KeyUp { .. } => {
                         vm.cpu.memory[0x04] = 0;
                     }
-                    Event::KeyDown { keycode, .. } => {
-                        if let Some(Keycode::Escape) = keycode {
-                            break 'running;
-                        } else if let Some(Keycode::Up) = keycode {
-                            vm.cpu.memory[0x04] = 38;
-                        } else if let Some(Keycode::Down) = keycode {
-                            vm.cpu.memory[0x04] = 40;
+                    Event::KeyDown { keycode, scancode, timestamp, keymod, .. } => {
+                        if !keymod.intersects(LALTMOD | LCTRLMOD | LSHIFTMOD | RALTMOD | RCTRLMOD | RSHIFTMOD) {
+                            if let Some(Scancode::Grave) = scancode {
+                                vm.console.toggle(timestamp);
+                            }
+                        }
+
+                        match keycode {
+                            Some(Keycode::Escape) => break 'running,
+
+                            //Movement
+                            Some(Keycode::Up) => {
+                                vm.cpu.memory[0x04] = 38;
+                            },
+                            Some(Keycode::Down) => {
+                                vm.cpu.memory[0x04]  = 40;
+                            },
+                            _ => (),
                         }
                     }
                     _ => (),

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use sdl2::event::Event;
 use sdl2::gfx::primitives::DrawRenderer;
-use sdl2::keyboard::Keycode;
+use sdl2::keyboard::*;
 use sdl2::pixels::{Color, PixelFormatEnum};
 use sdl2::rect::Rect;
 use sdl2::render::{BlendMode, Renderer, Texture, TextureQuery};
@@ -22,6 +22,7 @@ const FONT_SIZE: u16 = 18;
 
 pub struct Console<'a> {
     pub visible: bool,
+    visible_start_time: u32, // Used to ensure that the KeyDown event that opens the console does not trigger text input
 
     font_file: &'a str,
     leader: Text,
@@ -71,6 +72,8 @@ impl<'a> Console<'a> {
 
         Console {
             visible: false,
+            visible_start_time: 0,
+
             font_file: font_file,
             leader: Text::new(ttf_context,
                               &mut renderer,
@@ -98,12 +101,8 @@ impl<'a> Console<'a> {
 
     pub fn process(&mut self, event: &Event) {
         match *event {
-            Event::TextInput { ref text, .. } => {
-                if self.visible {
-                    if text == "`" || text == "\\" {
-                        self.toggle();
-                        return;
-                    }
+            Event::TextInput { ref text, timestamp, .. } => {
+                if self.visible && timestamp != self.visible_start_time {
                     self.add_text(text);
                 }
             }
@@ -118,8 +117,17 @@ impl<'a> Console<'a> {
                     }
                 }
             }
-            Event::KeyDown { keycode, .. } => {
+            Event::KeyDown { keycode, scancode, timestamp, keymod, .. } => {
                 if self.visible {
+                    if !keymod.intersects(LALTMOD | LCTRLMOD | LSHIFTMOD | RALTMOD | RCTRLMOD | RSHIFTMOD) {
+                        // The 'Grave' scancode coresponds to the key in the top-left corner of the
+                        // keyboard, bellow escape, on (hopefully) all keyboard layouts.
+                        if let Some(Scancode::Grave) = scancode {
+                            self.toggle(timestamp);
+                            return;
+                        } 
+                    }
+
                     match keycode { 
                         Some(Keycode::LCtrl) |
                         Some(Keycode::RCtrl) => self.ctrl = true,
@@ -260,8 +268,11 @@ impl<'a> Console<'a> {
     }
 
     /// Toggles the visibility of the Console
-    pub fn toggle(&mut self) {
+    pub fn toggle(&mut self, time: u32) {
         self.visible = !self.visible;
+        if self.visible {
+            self.visible_start_time = time;
+        }
     }
 
     pub fn add_text(&mut self, input: &str) {

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -129,7 +129,11 @@ impl<'a> VirtualMachine<'a> {
                     self.console.println("");
                     self.console
                         .println(format!("BREAKPOINT hit at {:04X}", self.cpu.registers.PC));
-                    self.console.toggle();
+                    // We are supposed to pass the current timestamp to prevent the keys which are
+                    // used to toggle the console from inputing text into the console. As no key
+                    // is pressed to open the console in this instance, passing the time is not
+                    // strictly necesarry
+                    self.console.toggle(0);
                 }
                 // If we stepped, dump the local disassembly
                 if self.step {
@@ -147,7 +151,7 @@ impl<'a> VirtualMachine<'a> {
                 self.broken = true;
                 self.console.println("");
                 self.console.println(format!("BREAKPOINT hit at {:04X}", self.cpu.registers.PC));
-                self.console.toggle();
+                self.console.toggle(0);
             }
         }
     }


### PR DESCRIPTION
This makes it so that the grave key (Below escape) will toggle the console, regardless of keyboard layouts. While this is advantageous in that it makes opening the console more uniform across platforms. However, it adds some complication to the code, which might be desirable to avoid.