### PR TITLE
Only disable rendering for game screen

### DIFF
--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -290,6 +290,10 @@ impl<'a> VirtualMachine<'a> {
             self.monitor.enabled = true;
         }
     }
+    
+    pub fn in_stepping_mode(&self) -> bool {
+        self.broken
+    }
 
     fn dump_disassembly(&mut self) {
         self.console.println("");


### PR DESCRIPTION
- Setting the interrupt disabled flag now disables only rendering
  of the game screen, leaving the console window responsive (fixes #7)
- Instead of the game screen, a blank screen is visible then
- When not in stepping mode, the handling remains as is; disabling
  rendering alltogether while the interrupt disabled flag is set.