### PR TITLE
Change Console owner

### DIFF
--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -21,7 +21,7 @@ use sdl2::rect::Rect;
 use sdl2::render::{Renderer, TextureQuery};
 
 use rs6502::{Assembler, CodeSegment, Cpu};
-use vm::{Console, Position, Text, VirtualMachine};
+use vm::{Position, Text, VirtualMachine};
 
 const FPS_STEP: u32 = 1000 / 60;
 
@@ -72,8 +72,11 @@ fn main() {
     let TextureQuery { width: ship_width, .. } = ship_texture.query();
     let cpu = init_cpu(&mut renderer, ship_width);
     let segments = assemble(local.join("level.asm"));
-    let console = Console::new(&ttf_context, &mut renderer, font.to_str().unwrap());
-    let mut vm = VirtualMachine::new(cpu, 150, console);
+    let mut vm = VirtualMachine::new(cpu,
+                                     150,
+                                     &ttf_context,
+                                     &mut renderer,
+                                     font.to_str().unwrap());
     vm.load_code_segments(segments);
 
     let mut events = sdl_context.event_pump().unwrap();

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -12,8 +12,10 @@ mod config;
 
 use rs6502::{CodeSegment, Cpu, Disassembler};
 use sdl2::render::Renderer;
+use sdl2::ttf::Sdl2TtfContext;
 
-pub use self::console::Console;
+use self::console::Console;
+
 pub use self::position::Position;
 pub use self::text::Text;
 
@@ -83,9 +85,16 @@ pub struct VirtualMachine<'a> {
 }
 
 impl<'a> VirtualMachine<'a> {
-    pub fn new<CR>(cpu: Cpu, clock_rate: CR, mut console: Console<'a>) -> VirtualMachine<'a>
+    pub fn new<CR>(cpu: Cpu,
+                   clock_rate: CR,
+                   ttf_context: &'a Sdl2TtfContext,
+                   mut renderer: &mut Renderer,
+                   font_file: &'a str)
+                   -> VirtualMachine<'a>
         where CR: Into<Option<u32>>
     {
+        let mut console = Console::new(ttf_context, renderer, font_file);
+
         console.println("Welcome to hakka. Type 'help' for instructions.");
         console.println("");
 


### PR DESCRIPTION
This PR moves instantiation and ownership of the `Console` instance into the `VirtualMachine`. Now levels will only need to instantiate a `VirtualMachine` instance and they'll get the `Console` for free.