### PR TITLE
Bump rs6502 to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hakka"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 
 [lib]
@@ -13,7 +13,7 @@ path = "training-1/src/main.rs"
 
 [dependencies]
 byteorder = "0.5.3"
-rs6502 = "0.2.0"
+rs6502 = "0.3.0"
 vm = { path = "vm" }
 find_folder = "0.3.0"
 app_dirs = "1.1.1"

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -78,6 +78,7 @@ fn main() {
                                      &mut renderer,
                                      font.to_str().unwrap());
     vm.load_code_segments(segments);
+    vm.cpu.reset();
 
     let mut events = sdl_context.event_pump().unwrap();
 

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "vm"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 
 [dependencies]
-rs6502 = "0.2.0"
+rs6502 = "0.3.0"
 find_folder = "0.3.0"
 app_dirs = "1.1.1"
 rustc-serialize = "0.3.22"


### PR DESCRIPTION
This PR bumps the minor version of `hakka` and also bumps the dependency version of `rs6502` to `0.3.0`.

This version introduces interrupt vectors and the ability to handle interrupts at an Assembly level.