### PR TITLE
Organize command code

### DIFF
--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -132,7 +132,7 @@ fn main() {
 
         if !level_complete {
             if let Some(cmd) = vm.console.get_next_command() {
-                let success = command_system.execute(cmd, &mut vm.console);
+                let success = command_system.execute(cmd, &mut vm);
                 if !success {
                     writeln!(vm.console, "Command not recognized, type 'help' for a list of commands").unwrap();
                 }

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -22,7 +22,7 @@ use sdl2::rect::Rect;
 use sdl2::render::{Renderer, TextureQuery};
 
 use rs6502::{Assembler, CodeSegment, Cpu};
-use vm::{Position, Text, VirtualMachine, CommandSystem, Command};
+use vm::{Position, Text, VirtualMachine, CommandSystem};
 
 const FPS_STEP: u32 = 1000 / 60;
 

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -8,7 +8,6 @@ extern crate vm;
 mod ship;
 
 use std::path::Path;
-use std::io::Write;
 
 use byteorder::{ByteOrder, LittleEndian};
 
@@ -22,7 +21,7 @@ use sdl2::rect::Rect;
 use sdl2::render::{Renderer, TextureQuery};
 
 use rs6502::{Assembler, CodeSegment, Cpu};
-use vm::{Position, Text, VirtualMachine, CommandSystem, GameCore};
+use vm::{Position, Text, GameCore};
 
 const FPS_STEP: u32 = 1000 / 60;
 

--- a/training-1/src/main.rs
+++ b/training-1/src/main.rs
@@ -22,7 +22,7 @@ use sdl2::rect::Rect;
 use sdl2::render::{Renderer, TextureQuery};
 
 use rs6502::{Assembler, CodeSegment, Cpu};
-use vm::{Position, Text, VirtualMachine, CommandSystem};
+use vm::{Position, Text, VirtualMachine, CommandSystem, GameCore};
 
 const FPS_STEP: u32 = 1000 / 60;
 
@@ -69,21 +69,14 @@ fn main() {
                              Color::RGBA(0, 0, 0, 255),
                              font.to_str().unwrap());
 
-    let command_system = CommandSystem::new();
+    let mut game_core = GameCore::new(&ttf_context, &mut renderer, font.to_str().unwrap()); 
 
-    let mut cpu = Cpu::new();
     let TextureQuery { width: ship_width, .. } = ship_texture.query();
-    init_cpu_mem(&mut cpu, &mut renderer, ship_width);
-
-    let mut vm = VirtualMachine::new(cpu,
-                                     150, // Clock rate
-                                     &ttf_context,
-                                     &mut renderer,
-                                     font.to_str().unwrap());
+    init_cpu_mem(&mut game_core.vm.cpu, &mut renderer, ship_width);
 
     let segments = assemble(local.join("level.asm"));
-    vm.load_code_segments(segments);
-    vm.cpu.reset();
+    game_core.vm.load_code_segments(segments);
+    game_core.vm.cpu.reset();
 
     let mut events = sdl_context.event_pump().unwrap();
 
@@ -97,16 +90,16 @@ fn main() {
     'running: loop {
 
         for event in events.poll_iter() {
-            vm.console.process(&event);
+            game_core.process_event(&event);
 
-            if !vm.console.visible {
+            if !game_core.vm.console.visible {
                 match event {
                     Event::Quit { .. } => break 'running,
                     Event::KeyUp { keycode, .. } => {
                         match keycode {
                             Some(Keycode::Up) |
                             Some(Keycode::Down) => {
-                                vm.cpu.memory[0x04] = 0;
+                                game_core.vm.cpu.memory[0x04] = 0;
                             }
                             _ => (),
                         }
@@ -117,10 +110,10 @@ fn main() {
 
                             // Movement
                             Some(Keycode::Up) => {
-                                vm.cpu.memory[0x04] = 38;
+                                game_core.vm.cpu.memory[0x04] = 38;
                             }
                             Some(Keycode::Down) => {
-                                vm.cpu.memory[0x04] = 40;
+                                game_core.vm.cpu.memory[0x04] = 40;
                             }
                             _ => (),
                         }
@@ -131,18 +124,12 @@ fn main() {
         }
 
         if !level_complete {
-            if let Some(cmd) = vm.console.get_next_command() {
-                let success = command_system.execute(cmd, &mut vm);
-                if !success {
-                    writeln!(vm.console, "Command not recognized, type 'help' for a list of commands").unwrap();
-                }
-            }
-            ship.process(&vm.cpu.memory[..]);
+            ship.process(&game_core.vm.cpu.memory[..]);
 
             // Pull the ship back so it can't go past a certain spot
-            if ship.y <= 0x190 && ship.y >= 0x100 && vm.cpu.memory[0x04] != 0 {
-                vm.cpu.memory[0x02] = 0x90;
-                vm.cpu.memory[0x03] = 0x01;
+            if ship.y <= 0x190 && ship.y >= 0x100 && game_core.vm.cpu.memory[0x04] != 0 {
+                game_core.vm.cpu.memory[0x02] = 0x90;
+                game_core.vm.cpu.memory[0x03] = 0x01;
             }
         }
 
@@ -151,24 +138,24 @@ fn main() {
         if delta < FPS_STEP {
             sdl_context.timer().unwrap().delay(FPS_STEP - delta);
         } else {
-            vm.cycle();
+            game_core.update();
 
             // Rendering only the background when interrupts are disabled results in a horrible
             // flickering; therefore only render when we're either in single stepping mode or
             // interrupts are enabled
-            if vm.is_debugging() || !vm.cpu.flags.interrupt_disabled {
+            if game_core.vm.is_debugging() || !game_core.vm.cpu.flags.interrupt_disabled {
                 renderer.set_draw_color(Color::RGBA(0, 0, 0, 255));
                 renderer.clear();
 
                 // Render complete game screen only if interrupts are enabled
-                if !vm.cpu.flags.interrupt_disabled {
+                if !game_core.vm.cpu.flags.interrupt_disabled {
                     if level_complete {
                         draw_passed_background(&mut renderer);
                         win_text.render(&mut renderer);
                     }
                     draw_finish_background(&mut renderer);
                     finish_text.render(&mut renderer);
-                    if vm.cpu.memory[0x07] > 0 {
+                    if game_core.vm.cpu.memory[0x07] > 0 {
                         ship.render_flame(&mut renderer);
                     }
                     ship.render(&mut renderer);
@@ -176,7 +163,7 @@ fn main() {
                         level_complete = true;
                     }
                 }
-                vm.render(&mut renderer);
+                game_core.vm.render(&mut renderer);
                 renderer.present();
                 last_fps = now;
             }
@@ -184,8 +171,8 @@ fn main() {
 
         // Dump the CPU memory at 1 second intervals if the monitor is enabled
         let delta = now - monitor_last;
-        if delta > 1000 && vm.monitor.enabled {
-            vm.dump_memory();
+        if delta > 1000 && game_core.vm.monitor.enabled {
+            game_core.vm.dump_memory();
             monitor_last = now;
         }
     }

--- a/vm/src/command.rs
+++ b/vm/src/command.rs
@@ -1,15 +1,6 @@
 
 // TODO:
 // Implement repeat command
-// Add some way for help messages to display parameters
-// Implement missing commands (Need flags, which need to be shown in help)
-//  - monitor | mon (Note: Monitor command needs some way to cancel monitoring)
-//  - memset | set
-//  - memdmp | dmp
-//  - flags
-//  - break | b
-//  - continue | c
-//  - step | s
 
 use std::io::Write;
 use vm::VirtualMachine;
@@ -28,6 +19,13 @@ impl CommandSystem {
         system.add_command(SourceCommand);
         system.add_command(ListCommand);
         system.add_command(RegistersCommand);
+        system.add_command(StepCommand);
+        system.add_command(ContinueCommand);
+        system.add_command(BreakCommand);
+        system.add_command(FlagsCommand);
+        system.add_command(MemdmpCommand);
+        system.add_command(MemsetCommand);
+        system.add_command(MonitorCommand);
 
         system
     }
@@ -99,7 +97,6 @@ impl Command for HelpCommand {
                     writeln!(vm.console, "      {}", help_line).unwrap();;
                 }
             }
-            writeln!(vm.console, "").unwrap();
         }
     }
 
@@ -173,6 +170,252 @@ impl Command for RegistersCommand {
     fn get_help(&self) -> &str {
         "Lists the CPU registers and their current
          values."
+    }
+}
+
+struct MonitorCommand;
+impl Command for MonitorCommand {
+    fn execute(&self, args: Vec<String>, _system: &CommandSystem, vm: &mut VirtualMachine) {
+        if args.is_empty() && vm.is_memory_monitor_enabled() {
+            vm.disable_memory_monitor();
+            writeln!(vm.console, "Disabling memory monitor").unwrap();
+            return;
+        }
+
+        if args.len() != 2 {
+            writeln!(vm.console, "Expected 2 arguments, found {}", args.len()).unwrap();
+            return;
+        }
+
+        let start = usize::from_str_radix(&args[0].replace("0x", "")[..], 16);
+        if start.is_err() {
+            writeln!(vm.console, "Expected hexadecimal memory address, found {}", args[0]).unwrap();
+            return;
+        }
+        let start = start.unwrap();
+        
+        let end = usize::from_str_radix(&args[1].replace("0x", "")[..], 16);
+        if end.is_err() {
+            writeln!(vm.console, "Expected hexadecimal memory address, found {}", args[1]).unwrap();
+            return;
+        }
+        let end = end.unwrap();
+
+        vm.enable_memory_monitor(start..end);
+    }
+
+    fn get_names(&self) -> Vec<&str> {
+        vec!["monitor", "mon"]
+    }
+    
+    fn get_arg_info(&self) -> Option<&str> {
+        Some("start end")
+    }
+
+    fn get_help(&self) -> &str {
+        "Dumps the memory between <start> and <end>
+         (inclusive) every seconds. Press ENTER to
+         stop monitoring."
+    }
+}
+
+struct MemsetCommand;
+impl Command for MemsetCommand {
+    fn execute(&self, args: Vec<String>, _system: &CommandSystem, vm: &mut VirtualMachine) {
+        if args.len() < 2 {
+            writeln!(vm.console,
+                "Expected 2 arguments. E.g.: memset 0x00 0x01 stores 0x01 at address 0x00"
+            ).unwrap();
+            return;
+        }
+
+        let start = usize::from_str_radix(&args[0].replace("0x", "")[..], 16);
+        if start.is_err() {
+            writeln!(vm.console, "Expected hexadecimal memory address, found {}", args[0]).unwrap();
+            return;
+        }
+        let start = start.unwrap();
+
+        let bytes = {
+            let mut bytes = Vec::new();
+            for index in 1..args.len() {
+                let byte = u8::from_str_radix(&args[index].replace("0x", "")[..], 16);
+                if byte.is_err() {
+                    writeln!(vm.console, "Expected hexadecimal byte, found {}", args[index]).unwrap();
+                    return;
+                }
+                bytes.push(byte.unwrap());
+            }
+            bytes
+        };
+
+        for (index, byte) in bytes.iter().enumerate() {
+            vm.cpu.memory[start + index] = *byte;
+        }
+    }
+
+    fn get_names(&self) -> Vec<&str> {
+        vec!["memset", "set"]
+    }
+    
+    fn get_arg_info(&self) -> Option<&str> {
+        Some("addres value [values, ...]")
+    }
+
+    fn get_help(&self) -> &str {
+        "Writes the given value to the given address.
+         Multiple values will be written to consequent
+         addresses."
+    }
+}
+
+struct MemdmpCommand;
+impl Command for MemdmpCommand {
+    fn execute(&self, args: Vec<String>, _system: &CommandSystem, vm: &mut VirtualMachine) {
+        if args.is_empty() || args.len() > 2 {
+            writeln!(vm.console, "Expected either 1 or 2 arguments, found {}", args.len()).unwrap();
+            return;
+        }
+
+        // Dump a page
+        if args.len() == 1 {
+            let page = usize::from_str_radix(&args[0].replace("0x", "")[..], 16);
+            if page.is_err() {
+                writeln!(vm.console, "Expected page index, found {}", args[0]).unwrap();
+                return;
+            }
+            let page = page.unwrap();
+
+            vm.dump_memory_page(page);
+
+        // Dump a range
+        } else if args.len() == 2 { 
+            let start = usize::from_str_radix(&args[0].replace("0x", "")[..], 16);
+            if start.is_err() {
+                writeln!(vm.console, "Expected hexadecimal memory address, found {}", args[0]).unwrap();
+                return;
+            }
+            let start = start.unwrap();
+
+            let end = usize::from_str_radix(&args[1].replace("0x", "")[..], 16);
+            if end.is_err() {
+                writeln!(vm.console, "Expected hexadecimal memory address, found {}", args[1]).unwrap();
+                return;
+            }
+            let end = end.unwrap();
+
+            vm.dump_memory_range(start, end);
+        }
+    }
+
+    fn get_names(&self) -> Vec<&str> {
+        vec!["memdmp", "dmp"]
+    }
+    
+    fn get_arg_info(&self) -> Option<&str> {
+        Some("page OR start end")
+    }
+
+    fn get_help(&self) -> &str {
+        "Dumps a single memory page, or a specified memory
+         range from <start> to <end>."
+    }
+}
+
+struct FlagsCommand;
+impl Command for FlagsCommand {
+    fn execute(&self, _args: Vec<String>, _system: &CommandSystem, vm: &mut VirtualMachine) {
+        vm.dump_flags();
+    }
+
+    fn get_names(&self) -> Vec<&str> {
+        vec!["flags"]
+    }
+
+    fn get_help(&self) -> &str {
+        "Not yet implemented"
+    }
+}
+
+struct BreakCommand;
+impl Command for BreakCommand {
+    fn execute(&self, args: Vec<String>, _system: &CommandSystem, vm: &mut VirtualMachine) {
+        if args.len() > 1 {
+            writeln!(vm.console, "Expected 0 or 1 arguments, found {}", args.len()).unwrap();
+            return;
+        }
+
+        // Break at the given address
+        if args.len() == 1 {
+            let address = usize::from_str_radix(&args[0].replace("0x", "")[..], 16);
+            if address.is_err() {
+                writeln!(vm.console, "Expected hexadecimal memory address, found {}", args[0]).unwrap();
+            }
+            let address = address.unwrap();
+
+            if address <= u16::max_value() as usize {
+                if vm.toggle_breakpoint(address) {
+                    writeln!(vm.console, "Added breakpoint at {:04X}", address).unwrap();
+                } else {
+                    writeln!(vm.console, "Removed breakpoint at {:04X}", address).unwrap();
+                }
+            } else {
+                writeln!(vm.console, "Address outside addressable range.").unwrap();
+            }
+
+        // Break at current program counter
+        } else {
+            vm.break_execution();
+            writeln!(vm.console, "Breaking execution at {:04X}", vm.cpu.registers.PC).unwrap();
+        }
+    }
+
+    fn get_names(&self) -> Vec<&str> {
+        vec!["break", "b"]
+    }
+
+    fn get_arg_info(&self) -> Option<&str> {
+        Some("[address]")
+    }
+
+    fn get_help(&self) -> &str {
+        "Toggles a breakpoint at the specified <address>.
+         If the program counter hits this address, execution
+         stops. If no address is specified, execution will
+         be stopped at the current point, without inserting
+         a program counter."
+    }
+}
+
+struct ContinueCommand;
+impl Command for ContinueCommand {
+    fn execute(&self, _args: Vec<String>, _system: &CommandSystem, vm: &mut VirtualMachine) {
+        vm.continue_execution();
+    }
+
+    fn get_names(&self) -> Vec<&str> {
+        vec!["continue", "c"]
+    }
+
+    fn get_help(&self) -> &str {
+        "Resumes program execution after the program
+         has stopped at a breakpoint."
+    }
+}
+
+struct StepCommand;
+impl Command for StepCommand {
+    fn execute(&self, _args: Vec<String>, _system: &CommandSystem, vm: &mut VirtualMachine) {
+        vm.step_execution();
+    }
+
+    fn get_names(&self) -> Vec<&str> {
+        vec!["step", "s"]
+    }
+
+    fn get_help(&self) -> &str {
+        "Executes a single instruction, then stops
+         execution"
     }
 }
 

--- a/vm/src/command.rs
+++ b/vm/src/command.rs
@@ -1,0 +1,89 @@
+
+use std::io::Write;
+
+pub struct CommandSystem {
+    commands: Vec<Box<Command>>, 
+}
+impl CommandSystem {
+    pub fn new() -> CommandSystem {
+        let mut system = CommandSystem {
+            commands: Vec::new()
+        };
+
+        // Add default commands
+        system.add_command(HelpCommand);
+        system.add_command(GreetCommand);
+
+        system
+    }
+
+    pub fn add_command<C>(&mut self, command: C)
+        where C: Command + 'static
+    {
+        self.commands.push(Box::new(command));
+    }
+
+    pub fn execute<S>(&self, command: S, mut out: &mut Write) -> bool
+        where S: Into<String>
+    {
+        let command = command.into();
+        let parts = command.split_whitespace().map(String::from).collect::<Vec<_>>();
+
+        for command in &self.commands {
+            if command.matches_name(parts[0].clone()) {
+                command.execute(parts[1..].to_owned(), &self, &mut out);
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+pub trait Command {
+    fn execute(&self, args: Vec<String>, system: &CommandSystem, out: &mut Write);
+    fn matches_name(&self, name: String) -> bool;
+    fn get_help(&self) -> String {
+        String::from("No help text provided")
+    }
+}
+
+struct HelpCommand;
+impl Command for HelpCommand {
+    fn execute(&self, _args: Vec<String>, system: &CommandSystem, out: &mut Write) {
+        writeln!(out, "Commands:").unwrap();
+        for command in &system.commands {
+            writeln!(out, "    {}", command.get_help()).unwrap();
+        }
+    }
+
+    fn matches_name(&self, name: String) -> bool {
+        name == "help" || name == "h" || name == "?"
+    }
+
+    fn get_help(&self) -> String {
+        String::from("help, h, ?      Prints this help message")
+    } 
+}
+
+struct GreetCommand;
+impl Command for GreetCommand {
+    fn execute(&self, args: Vec<String>, _system: &CommandSystem, out: &mut Write) {
+        if args.is_empty() {
+            writeln!(out, "Hello world!").unwrap();
+        } else {
+            for name in args {
+                writeln!(out, "Hello {}!", name).unwrap();
+            }
+        }
+    }
+
+    fn matches_name(&self, name: String) -> bool {
+        name == "greet" || name == "g"
+    }
+
+    fn get_help(&self) -> String {
+        String::from("greet, g        Greets the given person")
+    } 
+}
+

--- a/vm/src/command.rs
+++ b/vm/src/command.rs
@@ -1,4 +1,5 @@
 
+use std;
 use std::io::Write;
 use vm::VirtualMachine;
 
@@ -25,6 +26,7 @@ impl CommandSystem {
         system.add_command(MemdmpCommand);
         system.add_command(MemsetCommand);
         system.add_command(MonitorCommand);
+        system.add_command(ExitCommand);
 
         system
     }
@@ -452,3 +454,17 @@ impl Command for StepCommand {
     }
 }
 
+struct ExitCommand;
+impl Command for ExitCommand {
+    fn execute(&self, _args: Vec<String>, _system: &CommandSystem, _vm: &mut VirtualMachine) -> CommandResult {
+        std::process::exit(0);
+    }
+
+    fn get_names(&self) -> Vec<&str> {
+        vec!["exit"]
+    }
+
+    fn get_help(&self) -> &str {
+        "Quits the game"
+    }
+}

--- a/vm/src/command.rs
+++ b/vm/src/command.rs
@@ -57,9 +57,15 @@ impl CommandSystem {
 
 pub trait Command {
     fn execute(&self, args: Vec<String>, system: &CommandSystem, vm: &mut VirtualMachine);
+
     fn get_names(&self) -> Vec<&str>;
-    fn get_help(&self) -> String {
-        String::from("No help text provided")
+
+    fn get_arg_info(&self) -> Option<&str> {
+        None
+    }
+
+    fn get_help(&self) -> &str {
+        "No help text provided!"
     }
 
     fn matches_name(&self, name: String) -> bool {
@@ -80,7 +86,11 @@ impl Command for HelpCommand {
         // Creates strings containing all names, e.g. "help, h, ?"
         for command in system.commands.iter() {
             let name = command.get_names().join(", ");
-            writeln!(vm.console, "   {}", name).unwrap();
+            write!(vm.console, "   {}", name).unwrap();
+            if let Some(arg_info) = command.get_arg_info() {
+                write!(vm.console, ": {}", arg_info).unwrap();
+            }
+            writeln!(vm.console, "").unwrap();
 
             let help = command.get_help();
             let help_lines = help.trim().lines().map(|line| line.trim()).collect::<Vec<_>>();
@@ -89,6 +99,7 @@ impl Command for HelpCommand {
                     writeln!(vm.console, "      {}", help_line).unwrap();;
                 }
             }
+            writeln!(vm.console, "").unwrap();
         }
     }
 
@@ -96,8 +107,8 @@ impl Command for HelpCommand {
         vec!["help", "h", "?"]
     }
 
-    fn get_help(&self) -> String {
-        String::from("Prints this help message")
+    fn get_help(&self) -> &str {
+        "Prints this help message"
     } 
 }
 
@@ -111,10 +122,8 @@ impl Command for ClearCommand {
         vec!["clear", "cls"]
     }
 
-    fn get_help(&self) -> String {
-        String::from("
-            Clears the console
-        ")
+    fn get_help(&self) -> &str {
+        "Clears the console"
     }
 }
 
@@ -128,12 +137,10 @@ impl Command for SourceCommand {
         vec!["source"]
     }
 
-    fn get_help(&self) -> String {
-        String::from("
-            Lists the code currently running in the virtual
-            machine. A '>' symbol indicates the current
-            program counter.
-        ")
+    fn get_help(&self) -> &str {
+        "Lists the code currently running in the virtual
+         machine. A '>' symbol indicates the current
+         program counter."
     }
 }
 
@@ -147,11 +154,9 @@ impl Command for ListCommand {
         vec!["list"]
     }
 
-    fn get_help(&self) -> String {
-        String::from("
-            Lists the code surrounding the current
-            program counter.
-        ")
+    fn get_help(&self) -> &str {
+        "Lists the code surrounding the current
+         program counter."
     }
 }
 
@@ -165,11 +170,9 @@ impl Command for RegistersCommand {
         vec!["registers", "reg"]
     }
 
-    fn get_help(&self) -> String {
-        String::from("
-            Lists the CPU registers and their current
-            values.
-        ")
+    fn get_help(&self) -> &str {
+        "Lists the CPU registers and their current
+         values."
     }
 }
 

--- a/vm/src/command.rs
+++ b/vm/src/command.rs
@@ -1,5 +1,6 @@
 
 use std::io::Write;
+use vm::VirtualMachine;
 
 pub struct CommandSystem {
     commands: Vec<Box<Command>>, 
@@ -23,7 +24,7 @@ impl CommandSystem {
         self.commands.push(Box::new(command));
     }
 
-    pub fn execute<S>(&self, command: S, mut out: &mut Write) -> bool
+    pub fn execute<S>(&self, command: S, mut vm: &mut VirtualMachine) -> bool
         where S: Into<String>
     {
         let command = command.into();
@@ -31,7 +32,7 @@ impl CommandSystem {
 
         for command in &self.commands {
             if command.matches_name(parts[0].clone()) {
-                command.execute(parts[1..].to_owned(), &self, &mut out);
+                command.execute(parts[1..].to_owned(), &self, &mut vm);
                 return true;
             }
         }
@@ -41,7 +42,7 @@ impl CommandSystem {
 }
 
 pub trait Command {
-    fn execute(&self, args: Vec<String>, system: &CommandSystem, out: &mut Write);
+    fn execute(&self, args: Vec<String>, system: &CommandSystem, vm: &mut VirtualMachine);
     fn matches_name(&self, name: String) -> bool;
     fn get_help(&self) -> String {
         String::from("No help text provided")
@@ -50,10 +51,10 @@ pub trait Command {
 
 struct HelpCommand;
 impl Command for HelpCommand {
-    fn execute(&self, _args: Vec<String>, system: &CommandSystem, out: &mut Write) {
-        writeln!(out, "Commands:").unwrap();
+    fn execute(&self, _args: Vec<String>, system: &CommandSystem, vm: &mut VirtualMachine) {
+        writeln!(vm.console, "Commands:").unwrap();
         for command in &system.commands {
-            writeln!(out, "    {}", command.get_help()).unwrap();
+            writeln!(vm.console, "    {}", command.get_help()).unwrap();
         }
     }
 
@@ -68,12 +69,12 @@ impl Command for HelpCommand {
 
 struct GreetCommand;
 impl Command for GreetCommand {
-    fn execute(&self, args: Vec<String>, _system: &CommandSystem, out: &mut Write) {
+    fn execute(&self, args: Vec<String>, _system: &CommandSystem, vm: &mut VirtualMachine) {
         if args.is_empty() {
-            writeln!(out, "Hello world!").unwrap();
+            writeln!(vm.console, "Hello world!").unwrap();
         } else {
             for name in args {
-                writeln!(out, "Hello {}!", name).unwrap();
+                writeln!(vm.console, "Hello {}!", name).unwrap();
             }
         }
     }

--- a/vm/src/command.rs
+++ b/vm/src/command.rs
@@ -1,7 +1,4 @@
 
-// TODO:
-// Implement repeat command
-
 use std::io::Write;
 use vm::VirtualMachine;
 
@@ -383,7 +380,7 @@ impl Command for BreakCommand {
          If the program counter hits this address, execution
          stops. If no address is specified, execution will
          be stopped at the current point, without inserting
-         a program counter."
+         a breakpoint."
     }
 }
 

--- a/vm/src/command.rs
+++ b/vm/src/command.rs
@@ -10,9 +10,9 @@ impl CommandSystem {
             commands: Vec::new()
         };
 
-        // Add default commands
         system.add_command(HelpCommand);
         system.add_command(GreetCommand);
+        // TODO: Implement 'repeat' as default command
 
         system
     }

--- a/vm/src/command.rs
+++ b/vm/src/command.rs
@@ -43,9 +43,18 @@ impl CommandSystem {
 
 pub trait Command {
     fn execute(&self, args: Vec<String>, system: &CommandSystem, vm: &mut VirtualMachine);
-    fn matches_name(&self, name: String) -> bool;
+    fn get_names(&self) -> Vec<&str>;
     fn get_help(&self) -> String {
         String::from("No help text provided")
+    }
+
+    fn matches_name(&self, name: String) -> bool {
+        for actual_name in self.get_names() {
+            if actual_name == name {
+                return true;
+            }
+        }
+        return false
     }
 }
 
@@ -53,17 +62,24 @@ struct HelpCommand;
 impl Command for HelpCommand {
     fn execute(&self, _args: Vec<String>, system: &CommandSystem, vm: &mut VirtualMachine) {
         writeln!(vm.console, "Commands:").unwrap();
-        for command in &system.commands {
-            writeln!(vm.console, "    {}", command.get_help()).unwrap();
+
+        // Creates strings containing all names, e.g. "help, h, ?"
+        let mut command_names = system.commands.iter().map(|c| c.get_names().join(", ")).collect::<Vec<_>>();
+        let longest_name_length = command_names.iter().max_by_key(|name| name.len()).map(|name| name.len()).unwrap_or(0);
+        let name_padding = longest_name_length + 2;
+
+        for (index, command) in system.commands.iter().enumerate() {
+            let ref name = command_names[index];
+            writeln!(vm.console, "    {0:1$}{2}", name, name_padding, command.get_help()).unwrap();
         }
     }
 
-    fn matches_name(&self, name: String) -> bool {
-        name == "help" || name == "h" || name == "?"
+    fn get_names(&self) -> Vec<&str> {
+        vec!["help", "h", "?"]
     }
 
     fn get_help(&self) -> String {
-        String::from("help, h, ?      Prints this help message")
+        String::from("Prints this help message")
     } 
 }
 
@@ -79,12 +95,12 @@ impl Command for GreetCommand {
         }
     }
 
-    fn matches_name(&self, name: String) -> bool {
-        name == "greet" || name == "g"
+    fn get_names(&self) -> Vec<&str> {
+        vec!["greet", "g"]
     }
 
     fn get_help(&self) -> String {
-        String::from("greet, g        Greets the given person")
-    } 
+        String::from("Greets the given person")
+    }
 }
 

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -247,10 +247,6 @@ impl<'a> Console<'a> {
         if !command.is_empty() {
             self.command_history.push(command.clone());
             self.last_command = command.clone();
-
-            if command == "exit" {
-                std::process::exit(0);
-            }
         }
     }
 

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -290,7 +290,7 @@ impl<'a> Console<'a> {
         }
     }
 
-    pub fn try_process_command(&mut self) -> Option<String> {
+    pub fn get_next_command(&mut self) -> Option<String> {
         if !self.last_command.is_empty() {
             let cmd = self.last_command.clone();
             self.last_command.clear();

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -30,6 +30,7 @@ const FONT_SIZE: u16 = 18;
 
 pub struct Console<'a> {
     pub visible: bool,
+    pub input_blocked: bool,
     visible_start_time: u32, /* Used to ensure that the KeyDown event that opens the console does not trigger text input */
 
     config: Configuration,
@@ -47,8 +48,6 @@ pub struct Console<'a> {
     ttf_context: &'a Sdl2TtfContext,
     size: (u32, u32),
     font: Font<'a>,
-    ctrl: bool, // Tracks the Ctrl key being pressed
-    shift: bool, // Tracks the Shift key being pressed
 }
 
 impl<'a> Console<'a> {
@@ -135,8 +134,7 @@ impl<'a> Console<'a> {
             ttf_context: ttf_context,
             size: (width / 2, height),
             font: font,
-            ctrl: false,
-            shift: false,
+            input_blocked: false,
         }
     }
 
@@ -158,7 +156,7 @@ impl<'a> Console<'a> {
         // Main event processing, only run if visible
         match *event {
             Event::TextInput { ref text, timestamp, .. } => {
-                if self.visible && timestamp > self.visible_start_time + 50 {
+                if self.visible && timestamp > self.visible_start_time + 50 && !self.input_blocked {
                     self.add_text(text);
                 }
             }
@@ -176,45 +174,37 @@ impl<'a> Console<'a> {
                     if no_mods(keymod) && scancode == Some(self.config.get_scancode()) {
                         self.toggle(timestamp);
                         return;
-                    }
-
-                    match keycode { 
-                        Some(Keycode::LCtrl) |
-                        Some(Keycode::RCtrl) => self.ctrl = true,
-                        Some(Keycode::LShift) |
-                        Some(Keycode::RShift) => self.shift = true,
-                        Some(Keycode::C) => {
-                            if self.ctrl {
-                                self.input_buffer.push_str("^C");
-                                self.commit();
+                    } else if !self.input_blocked {
+                        match keycode { 
+                            Some(Keycode::C) => {
+                                if keymod.intersects(LCTRLMOD | RCTRLMOD) {
+                                    self.input_buffer.push_str("^C");
+                                    self.commit(false);
+                                }
                             }
-                        }
-                        Some(Keycode::Left) => {
-                            self.cursor_left();
-                        }
-                        Some(Keycode::Right) => {
-                            self.cursor_right();
-                        }
-                        Some(Keycode::Backspace) => {
-                            self.backspace();
-                        }
-                        Some(Keycode::Delete) => {
-                            if self.cursor_position < self.input_buffer.len() {
-                                self.cursor_position += 1;
+                            Some(Keycode::Left) => {
+                                self.cursor_left();
+                            }
+                            Some(Keycode::Right) => {
+                                self.cursor_right();
+                            }
+                            Some(Keycode::Backspace) => {
                                 self.backspace();
                             }
+                            Some(Keycode::Delete) => {
+                                if self.cursor_position < self.input_buffer.len() {
+                                    self.cursor_position += 1;
+                                    self.backspace();
+                                }
+                            }
+                            _ => (),
                         }
-                        _ => (),
                     }
                 }
             }
             Event::KeyUp { keycode, timestamp, .. } => {
-                if self.visible {
+                if self.visible && !self.input_blocked {
                     match keycode { 
-                        Some(Keycode::LCtrl) |
-                        Some(Keycode::RCtrl) => self.ctrl = false,
-                        Some(Keycode::LShift) |
-                        Some(Keycode::RShift) => self.shift = false,
                         Some(Keycode::Up) => {
                             // Special check that an automatic console toggle
                             // does not cause history navigation when holding the
@@ -236,7 +226,7 @@ impl<'a> Console<'a> {
                             }
                         }
                         Some(Keycode::Return) => {
-                            self.commit();
+                            self.commit(true);
                         }
                         Some(Keycode::End) => {
                             self.cursor_position = self.input_buffer.len();
@@ -313,11 +303,14 @@ impl<'a> Console<'a> {
         self.cursor_position += input.len();
     }
 
-    pub fn commit(&mut self) {
+    pub fn commit(&mut self, execute: bool) {
         let command = self.input_buffer.clone();
         writeln!(self, "hakka> {}", command).unwrap();
 
-        self.process_command();
+        if execute {
+            self.process_command();
+        }
+
         self.input_buffer.clear();
         self.cursor_position = 0;
         self.history_position = self.command_history.len();
@@ -362,26 +355,38 @@ impl<'a> Console<'a> {
                       Some(Rect::new(0, 0, self.size.0, self.size.1)))
                 .unwrap();
             self.generate_backbuffer_texture(&mut renderer);
-            self.render_leader(&mut renderer);
 
-            // Insert the cursor via a dodgy vertical line
-            let cursor_x =
-                60 + PADDING as i16 +
-                self.font.size_of(&self.input_buffer[..self.cursor_position]).unwrap().0 as i16;
-            // Draw a dodgy cursor
-            renderer.thick_line(cursor_x,
-                            self.size.1 as i16 - FONT_SIZE as i16 - PADDING as i16,
-                            cursor_x,
-                            self.size.1 as i16 - PADDING as i16,
-                            1,
-                            FONT_COLOR)
-                .unwrap();
+            if !self.input_blocked {
+                self.render_leader(&mut renderer);
+                // Insert the cursor via a dodgy vertical line
+                let cursor_x =
+                    60 + PADDING as i16 +
+                    self.font.size_of(&self.input_buffer[..self.cursor_position]).unwrap().0 as i16;
+                // Draw a dodgy cursor
+                renderer.thick_line(cursor_x,
+                                self.size.1 as i16 - FONT_SIZE as i16 - PADDING as i16,
+                                cursor_x,
+                                self.size.1 as i16 - PADDING as i16,
+                                1,
+                                FONT_COLOR)
+                    .unwrap();
 
-            if !self.input_buffer.is_empty() {
+                if !self.input_buffer.is_empty() {
+                    let text = Text::new(self.ttf_context,
+                                         &mut renderer,
+                                         &self.input_buffer[..],
+                                         Position::XY(60 + PADDING,
+                                                      self.size.1 as i32 - FONT_SIZE as i32 - PADDING),
+                                         FONT_SIZE,
+                                         FONT_COLOR,
+                                         self.font_file);
+                    text.render(&mut renderer);
+                }
+            } else {
                 let text = Text::new(self.ttf_context,
                                      &mut renderer,
-                                     &self.input_buffer[..],
-                                     Position::XY(60 + PADDING,
+                                     "Press Ctrl+C or ENTER to cancel",
+                                     Position::XY(PADDING,
                                                   self.size.1 as i32 - FONT_SIZE as i32 - PADDING),
                                      FONT_SIZE,
                                      FONT_COLOR,

--- a/vm/src/game_core.rs
+++ b/vm/src/game_core.rs
@@ -2,7 +2,7 @@
 use std::io::Write;
 
 use vm::VirtualMachine;
-use command::{CommandSystem, UnblockEvent};
+use command::{CommandSystem, UnblockEvent, CommandResult};
 
 use sdl2::render::Renderer;
 use sdl2::ttf::Sdl2TtfContext;
@@ -53,9 +53,9 @@ impl<'a> GameCore<'a> {
 
     pub fn update(&mut self) {
         if let Some(cmd) = self.vm.console.get_next_command() {
-            let (sucess, unblock_event) = self.command_system.execute(cmd, &mut self.vm);
+            let (result, unblock_event) = self.command_system.execute(cmd, &mut self.vm);
 
-            if !sucess {
+            if let CommandResult::NotFound = result {
                 writeln!(self.vm.console, "Command not recognized, type 'help' for a list of commands").unwrap();
             }
 

--- a/vm/src/game_core.rs
+++ b/vm/src/game_core.rs
@@ -34,16 +34,15 @@ impl<'a> GameCore<'a> {
     }
 
     pub fn process_event(&mut self, event: &Event) {
-        if self.unblock_event.is_some() {
-        }
         match *event {
             // Stop a blocking event
             Event::KeyDown { keycode, keymod, .. }
-            if keycode == Some(Keycode::C) &&
-               keymod.intersects(LCTRLMOD | RCTRLMOD) => {
+            if (keycode == Some(Keycode::C) && keymod.intersects(LCTRLMOD | RCTRLMOD) || keycode == Some(Keycode::Return)) &&
+               self.unblock_event.is_some() => {
                 if let Some(ref unblock_event) = self.unblock_event {
                     unblock_event(&mut self.vm);
                 }
+                self.vm.console.input_blocked = false;
                 self.unblock_event = None;
             },
             // Let the console handle the event
@@ -61,6 +60,7 @@ impl<'a> GameCore<'a> {
 
             if unblock_event.is_some() {
                 self.unblock_event = unblock_event;
+                self.vm.console.input_blocked = true;
             } else {
                 self.unblock_event = None;
             }

--- a/vm/src/game_core.rs
+++ b/vm/src/game_core.rs
@@ -1,0 +1,47 @@
+
+use std::io::Write;
+
+use vm::VirtualMachine;
+use console::Console;
+use command::{CommandSystem, Command};
+
+use sdl2::render::Renderer;
+use sdl2::ttf::Sdl2TtfContext;
+use sdl2::event::Event;
+
+use rs6502::Cpu;
+
+pub struct GameCore<'a> {
+    pub vm: VirtualMachine<'a>,
+    pub command_system: CommandSystem,
+}
+
+impl<'a> GameCore<'a> {
+    pub fn new(ttf_context: &'a Sdl2TtfContext,
+               mut renderer: &mut Renderer,
+               font_file: &'a str)
+               -> GameCore<'a>
+   {
+        let mut cpu = Cpu::new();
+        let mut vm = VirtualMachine::new(cpu, 150, &ttf_context, &mut renderer, font_file);
+
+        GameCore {
+            vm: vm,
+            command_system: CommandSystem::new(),
+        }
+    }
+
+    pub fn process_event(&mut self, event: &Event) {
+        self.vm.console.process(&event);
+    }
+
+    pub fn update(&mut self) {
+        if let Some(cmd) = self.vm.console.get_next_command() {
+            let success = self.command_system.execute(cmd, &mut self.vm);
+            if !success {
+                writeln!(self.vm.console, "Command not recognized, type 'help' for a list of commands").unwrap();
+            }
+        }
+        self.vm.cycle();
+    }
+}

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -15,4 +15,4 @@ mod vm;
 pub use self::position::Position;
 pub use self::text::Text;
 pub use self::vm::VirtualMachine;
-
+pub use self::command::{CommandSystem, Command};

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -11,8 +11,10 @@ mod text;
 mod config;
 mod command;
 mod vm;
+mod game_core;
 
 pub use self::position::Position;
 pub use self::text::Text;
 pub use self::vm::VirtualMachine;
 pub use self::command::{CommandSystem, Command};
+pub use self::game_core::GameCore;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -9,6 +9,7 @@ mod console;
 mod position;
 mod text;
 mod config;
+mod command;
 mod vm;
 
 pub use self::position::Position;

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -2,57 +2,8 @@
 use rs6502::{CodeSegment, Cpu, Disassembler};
 use sdl2::render::Renderer;
 use sdl2::ttf::Sdl2TtfContext;
-
 use console::Console;
-use command::CommandSystem;
-
 use std::io::Write;
-
-const HELPTEXT: &'static str = "
-
-HAKKA
------
-
-Commands:
-
-break | b: addr
-       - Toggles a breakpoint at a specific address. If the
-         program counter hits this address, execution
-         stops. 
-        
-step | s
-       - Executes the current instruction before breaking
-         execution again.
-
-continue | c
-       - Resumes execution of code within the virtual machine.
-
-list
-       - Lists the code surrounding the current program
-         counter.
-
-memset | set: addr args [args, ...]
-       - memset sets the value of memory directly.
-
-memdmp | dmp: page || start end
-       - memdmp dumps a single memory page, or a specified
-         memory range from <start> to <end> (inclusive).
-
-monitor | mon: start end
-       - monitor dumps the memory between start and end (inclusive)
-         every second. Press ENTER to stop the monitor.
-
-source
-       - Lists the code currently running in the virtual
-         machine. A '>' symbol indicates the current 
-         program counter.
-
-registers | reg
-       - Lists the CPU registers and their current values.
-
-help
-       - Lists this help text.
-";
 
 #[derive(Debug)]
 pub struct MemoryMonitor {
@@ -173,7 +124,7 @@ impl<'a> VirtualMachine<'a> {
         self.broken
     }
 
-    fn dump_disassembly(&mut self) {
+    pub fn dump_disassembly(&mut self) {
         writeln!(self.console, " ").unwrap();
 
         for segment in &self.segments {
@@ -192,7 +143,7 @@ impl<'a> VirtualMachine<'a> {
         writeln!(self.console, " ").unwrap();
     }
 
-    fn dump_local_disassembly(&mut self) {
+    pub fn dump_local_disassembly(&mut self) {
         writeln!(self.console, " ").unwrap();
 
         let result = {
@@ -231,7 +182,7 @@ impl<'a> VirtualMachine<'a> {
         }
     }
 
-    fn dump_memory_range(&mut self, start: u16, end: u16) {
+    pub fn dump_memory_range(&mut self, start: u16, end: u16) {
         let start = start as usize;
         let end = end as usize;
         for chunk in self.cpu.memory[start..end + 0x01].chunks(8) {
@@ -243,16 +194,17 @@ impl<'a> VirtualMachine<'a> {
         writeln!(self.console, "").unwrap();
     }
 
-    fn dump_registers(&mut self) {
+    pub fn dump_registers(&mut self) {
         writeln!(self.console, " ").unwrap();
         writeln!(self.console,"A: {} ({:04X})", self.cpu.registers.A, self.cpu.registers.A).unwrap();
         writeln!(self.console, "X: {} ({:04X})", self.cpu.registers.X, self.cpu.registers.X).unwrap();
         writeln!(self.console, "Y: {} ({:04X})", self.cpu.registers.Y, self.cpu.registers.Y).unwrap();
         writeln!(self.console, "PC: {} ({:04X})", self.cpu.registers.PC, self.cpu.registers.PC).unwrap();
         writeln!(self.console, "S: {} ({:04X})", self.cpu.stack.pointer, self.cpu.stack.pointer).unwrap();
+        writeln!(self.console, " ").unwrap();
     }
 
-    fn dump_flags(&mut self) {
+    pub fn dump_flags(&mut self) {
         writeln!(self.console, " ").unwrap();
         writeln!(self.console, "Carry: {}", self.cpu.flags.carry).unwrap();
         writeln!(self.console, "Zero: {}", self.cpu.flags.zero).unwrap();

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -65,10 +65,8 @@ pub struct VirtualMachine<'a> {
     pub cpu: Cpu,
     pub monitor: MemoryMonitor,
     pub console: Console<'a>,
-    pub command_system: CommandSystem,
     segments: Vec<CodeSegment>,
     clock_rate: Option<u32>,
-    last_command: String,
     breakpoints: [u8; 64 * 1024],
     broken: bool,
     step: bool,
@@ -91,7 +89,6 @@ impl<'a> VirtualMachine<'a> {
         VirtualMachine {
             cpu: cpu,
             console: console,
-            command_system: CommandSystem::new(),
             segments: Vec::new(),
             clock_rate: clock_rate.into(),
             monitor: MemoryMonitor {
@@ -99,7 +96,6 @@ impl<'a> VirtualMachine<'a> {
                 start_addr: 0,
                 end_addr: 0,
             },
-            last_command: "".into(),
             breakpoints: [0; 64 * 1024],
             broken: false,
             step: false,
@@ -157,132 +153,6 @@ impl<'a> VirtualMachine<'a> {
                 self.console.toggle(0);
             }
         }
-    }
-
-    pub fn execute_command<S>(&mut self, cmd: S)
-        where S: Into<String>
-    {
-        let cmd = cmd.into();
-
-        let sucess = self.command_system.execute(cmd.clone(), &mut self.console);
-        if !sucess {
-            writeln!(self.console, "Command not recognized, type 'help' for a list of commands").unwrap();
-        }
-
-        // Don't assign a blank command as a last command
-        if !cmd.is_empty() {
-            self.last_command = cmd.clone();
-        }
-
-//        if input == "r" || input == "repeat" {
-//            input = self.last_command.clone();
-//        }
-//
-//        let parts = input.split(' ').collect::<Vec<_>>();
-//
-//        if input.is_empty() {
-//            if self.monitor.enabled {
-//                self.monitor.enabled = false;
-//            }
-//        } else if input.ends_with("^C") {
-//            self.monitor.enabled = false;
-//        } else if parts[0] == "clear" || parts[0] == "cls" {
-//            self.console.clear();
-//        } else if parts[0] == "help" {
-//            write!(self.console, "{}", HELPTEXT).unwrap();
-//        } else if parts[0] == "source" {
-//            self.dump_disassembly();
-//        } else if parts[0] == "list" {
-//            self.dump_local_disassembly();
-//        } else if parts[0] == "monitor" || parts[0] == "mon" {
-//            if self.monitor.enabled {
-//                self.monitor.enabled = false;
-//            } else {
-//                self.enable_memory_monitor(&input);
-//            }
-//        } else if parts[0] == "memset" || parts[0] == "set" {
-//            if parts.len() < 3 {
-//                writeln!(self.console,
-//                    "ERR: Requires 2 arguments. Example: memset 0x00 0x01 to store 0x01 in 0x00."
-//                ) .unwrap();
-//            } else if parts.len() == 3 {
-//                if let Ok(dst) = u16::from_str_radix(&parts[1].replace("0x", "")[..], 16) {
-//                    if let Ok(src) = u8::from_str_radix(&parts[2].replace("0x", "")[..], 16) {
-//                        self.cpu.memory[dst as usize] = src;
-//                    } else {
-//                        writeln!(self.console, "ERR: Unable to parse source byte value").unwrap();
-//                    }
-//                } else {
-//                    writeln!(self.console, "ERR: Unable to parse destination byte value").unwrap();
-//                }
-//            } else if let Ok(mut dst) = usize::from_str_radix(&parts[1].replace("0x", "")[..], 16) {
-//                for p in &parts[2..] {
-//                    if let Ok(byte) = u8::from_str_radix(&p.replace("0x", "")[..], 16) {
-//                        self.cpu.memory[dst] = byte;
-//                        dst += 0x01;
-//                    } else {
-//                        writeln!(self.console, "ERR: Unable to parse source byte value").unwrap();
-//                    }
-//                }
-//            } else {
-//                writeln!(self.console, "ERR: Unable to parse destination byte value").unwrap();
-//            }
-//        } else if parts[0] == "memdmp" || parts[0] == "dmp" {
-//            // 1 argument assumes 1 memory "page"
-//            if parts.len() == 2 {
-//                if let Ok(page_number) = parts[1].parse() {
-//
-//                    self.dump_memory_page(page_number);
-//                } else {
-//                    writeln!(self.console, "ERR: Unable to parse memory page").unwrap()
-//                }
-//            } else if parts.len() == 3 {
-//                // A memory range instead
-//                if let Ok(start) = u16::from_str_radix(&parts[1].replace("0x", "")[..], 16) {
-//                    if let Ok(end) = u16::from_str_radix(&parts[2].replace("0x", "")[..], 16) {
-//                        self.dump_memory_range(start, end);
-//                    } else {
-//                        writeln!(self.console, "ERR: Unable to parse end address value").unwrap();
-//                    }
-//                } else {
-//                    writeln!(self.console, "ERR: Unable to parse start address value").unwrap();
-//                }
-//            }
-//        } else if parts[0] == "registers" || parts[0] == "reg" {
-//            self.dump_registers(); 
-//        } else if parts[0] == "flags" {
-//            self.dump_flags();
-//        } else if parts[0] == "break" || parts[0] == "b" {
-//            // 1 argument assumes 1 memory "page"
-//            if parts.len() == 2 {
-//                if let Ok(addr) = usize::from_str_radix(&parts[1][..], 16) {
-//                    if addr <= u16::max_value() as usize {
-//                        if self.breakpoints[addr] > 0 {
-//                            writeln!(self.console, "Remove breakpoint at {:04X}", addr).unwrap();
-//                            self.breakpoints[addr] = 0;
-//                        } else {
-//                            writeln!(self.console, "Added breakpoint at {:04X}", addr).unwrap();
-//                            self.breakpoints[addr] = 1;
-//                        }
-//                    } else {
-//                        writeln!(self.console, "ERR: Value outside addressable range.").unwrap();
-//                    }
-//                } else {
-//                    writeln!(self.console, "ERR: Unable to parse breakpoint address").unwrap();
-//                }
-//            } else {
-//                self.broken = true;
-//                writeln!(self.console, "Execution stopped").unwrap();
-//            }
-//        } else if parts[0] == "continue" || parts[0] == "c" {
-//            self.broken = false;
-//            writeln!(self.console, "Execution resumed").unwrap();
-//        } else if parts[0] == "step" || parts[0] == "s" {
-//            self.broken = true;
-//            self.step = true;
-//        } else {
-//            writeln!(self.console, "Unknown command").unwrap();
-//        }
     }
 
     fn enable_memory_monitor(&mut self, input: &str) {


### PR DESCRIPTION
See issue #20 for a in-depth discussion of this pull request.

Changes
- Commands are now managed by a separate module
- Each command is implemented as a unit struct, which implements a `Command` trait
- The `help` command message is dynamically generated
- Levels can define their own commands

Things that maybe should be done
- [ ] Move each command to it's own file
- [ ] Re-implement the `repeat` command (Although this might not be needed, one can use up-arrow to re-enter the previous command)