### PR TITLE
Add second Font lifetime parameter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ app_dirs = "1.1.1"
 rustc-serialize = "0.3.22"
 
 [dependencies.sdl2]
-version = "*"
+version = "^0.29"
 features = ["image", "ttf", "gfx"]

--- a/vm/src/console.rs
+++ b/vm/src/console.rs
@@ -47,7 +47,7 @@ pub struct Console<'a> {
     texture: Texture,
     ttf_context: &'a Sdl2TtfContext,
     size: (u32, u32),
-    font: Font<'a>,
+    font: Font<'a, 'a>,
 }
 
 impl<'a> Console<'a> {


### PR DESCRIPTION
Compiling with `sdl2 v0.29.1`, I get this error.

```rust
error[E0107]: wrong number of lifetime parameters: expected 2, found 1
  --> vm/src/console.rs:50:11
   |
50 |     font: Font<'a>,
   |           ^^^^^^^^ expected 2 lifetime parameters
```

Duplicating the parameter allows the game to run successfully.

It looks like this change was made in: https://github.com/AngryLawyer/rust-sdl2/commit/7b7d20c5febc35822433bda46a0753e371df333f, as it's backwards-incompatible, I also updated the minimum sdl2 version.